### PR TITLE
Add keyword search

### DIFF
--- a/site/_data/allSubjects.js
+++ b/site/_data/allSubjects.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 
-module.exports = function allSubjects() {
+function allSubjects() {
   let subjects = [];
   fs.readdirSync('./site/_data/subjects').forEach(file => {
     const groupSubjects = require(`./subjects/${file}`)
@@ -10,3 +10,5 @@ module.exports = function allSubjects() {
   console.log('Total number of subjects:', subjects.length)
   return subjects
 }
+
+module.exports = allSubjects()

--- a/site/tags/search.11tydata.js
+++ b/site/tags/search.11tydata.js
@@ -1,0 +1,11 @@
+function searchIndex({ allTags }) {
+  return Object.entries(allTags).map(([key, value]) => ({ tagName: value.tagName, slug: key }));
+}
+
+module.exports = {
+  eleventyComputed: {
+    searchIndex,
+    title: 'Keyword search',
+    description: 'Search for keywords that have been added by our volunteers.'
+  }
+}

--- a/site/tags/search.njk
+++ b/site/tags/search.njk
@@ -1,0 +1,40 @@
+---
+layout: default
+permalink: '/tags/search/'
+---
+<search>
+  <h1>Tag search</h1>
+  <form id="searchForm">
+    <label for="tagName">Search tags</label>
+    <input id="tagName" type="text" name="tagName" /> <button type="submit">Go</button>
+  </form>
+</search>
+
+<p id="results">
+</p>
+
+<script>
+const allTags = {{ searchIndex | dump | safe }};
+const form = document.getElementById('searchForm');
+const textInput = document.getElementById('tagName');
+const results = document.getElementById('results');
+function doSearch() {
+  const formData = new FormData(form);
+  const searchText = formData.get('tagName');
+  const url = new URL(location);
+  url.searchParams.set('tagName', searchText);
+  history.replaceState({ searchText }, '', `${url.pathname}${url.search}`);
+  const tagLinks = allTags
+    .filter(tag => tag.slug.startsWith(searchText || ' '))
+    .map(tag => `<a href='../${tag.slug}/page/0/'>${tag.tagName}</a>`);
+    results.innerHTML = tagLinks.join(', ');
+}
+form.addEventListener('submit', doSearch);
+form.addEventListener('input', doSearch);
+const urlSearchParams = new URLSearchParams(location.search);
+const tagName = urlSearchParams.get('tagName');
+textInput.value = tagName ? tagName : '';
+if (tagName) {
+  doSearch();
+}
+</script>


### PR DESCRIPTION
Add a keyword search, which filters the tag index for tags with slugs that start with the typed text. The index and search script are inlined with the search form HTML.

Inspired by [Adding search to a JAMstack site](https://www.hawksworx.com/blog/adding-search-to-a-jamstack-site/).